### PR TITLE
Change wording at arduino day 2020 schedule

### DIFF
--- a/arduino.html
+++ b/arduino.html
@@ -117,7 +117,7 @@
             </div>
         </section>
         <div class="container" style="padding-top: 20px; padding-bottom: 20px;">
-            <h2 style="text-align: center;">Speaches</h2>
+            <h2 style="text-align: center;">Presentations</h2>
             <table class="table">
                 <thead>
                     <tr>


### PR DESCRIPTION
In this PR I changed the word "speeches" at the arduino day 2020 schedule, to "Presentations".

I believe it describes better the situation.

Other options could be: 
- Schedule
- Main track (since a workshop will happen in the same time).